### PR TITLE
looser rules for declaring incident lead

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var testCommand = &command{
 }
 
 var takingLeadCommand = &command{
-	regexp:      "[iI] am (the )?incident lead",
+	regexp:      "[iI]('?m?| am?) (the )?incident lead",
 	example:     "I am incident lead",
 	description: "Declare yourself incident-lead",
 }


### PR DESCRIPTION
a few online regex testers show that this accepts variations like
```
i'm incident lead
im incident lead
i am incident lead
i incident lead
```