### PR TITLE
add status page link and reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Flarebot provides links to documentation when a Flare is fired. This link is con
 
 * `FLARE_RESOURCES_URL`: a URL of Flare-handling resources, checklists, etc.
 
+### Status Page
+
+Flarebot provides a link to Clever's status page management when a Flare is fired. This link is configured as
+
+* `STATUS_PAGE_URL`: a URL for the status page.
+
 ## Usage
 
 ### Help
@@ -79,7 +85,7 @@ Lists all commands
 ### Fire a Flare
 
 ```
-@flarebot: fire a flare p2 District 9 users cannot log in 
+@flarebot: fire a flare p2 District 9 users cannot log in
 @channel: OK, go chat in #flare-4242
 ```
 

--- a/main.go
+++ b/main.go
@@ -128,10 +128,9 @@ func sendHelpMessage(client *slack.Client, jiraServer *jira.JiraServer, channel 
 	}
 }
 
-func sendReminderMessage(client *slack.Client, channel string) {
-	time.Sleep(5 * time.Minute)
-	client.Send("Have you tried rolling back, scaling or restarting?", channel)
-	client.Send("Are users affected? Consider creating an incident on the status page.", channel)
+func sendReminderMessage(client *slack.Client, channel string, message string, delay time.Duration) {
+	time.Sleep(delay)
+	client.Send(message, channel)
 }
 
 func main() {
@@ -338,7 +337,8 @@ func main() {
 		// let people know that they can rename this channel
 		client.Send(fmt.Sprintf("NOTE: you can rename this channel as long as it starts with %s", channel.Name), channel.ID)
 
-		go sendReminderMessage(client, channel.ID)
+		go sendReminderMessage(client, channel.ID, "Are users affected? Consider creating an incident on the status page.", 2*time.Minute)
+		go sendReminderMessage(client, channel.ID, "Have you tried rolling back, scaling or restarting?", 5*time.Minute)
 
 		// announce the specific Flare room in the overall Flares room
 		target := "channel"

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 	resources_url := os.Getenv("FLARE_RESOURCES_URL")
 
 	// Link to status page
-	status_page_url := os.Getenv("STATUS_PAGE_URL")
+	status_page_login_url := os.Getenv("STATUS_PAGE_LOGIN_URL")
 
 	// Slack connection params
 	var accessToken string
@@ -322,14 +322,14 @@ func main() {
 		client.Send(fmt.Sprintf("JIRA ticket: %s", ticket.Url()), channel.ID)
 		client.Send(fmt.Sprintf("Facts docs: %s", doc.File.AlternateLink), channel.ID)
 		client.Send(fmt.Sprintf("Flare resources: %s", resources_url), channel.ID)
-		client.Send(fmt.Sprintf("Manage status page: %s", status_page_url), channel.ID)
+		client.Send(fmt.Sprintf("Manage status page: %s", status_page_login_url), channel.ID)
 		client.Send(fmt.Sprintf("Remember: Rollback, Scale or Restart!"), channel.ID)
 
 		// Pin the most important messages. NOTE: that this is based on text
 		// matching, so the links need to be escaped to match
 		client.Pin(fmt.Sprintf("JIRA ticket: <%s>", ticket.Url()), channel.ID)
 		client.Pin(fmt.Sprintf("Facts docs: <%s>", doc.File.AlternateLink), channel.ID)
-		client.Pin(fmt.Sprintf("Manage status page: <%s>", status_page_url), channel.ID)
+		client.Pin(fmt.Sprintf("Manage status page: <%s>", status_page_login_url), channel.ID)
 		client.Pin(fmt.Sprintf("Remember: Rollback, Scale or Restart!"), channel.ID)
 
 		// send room-specific help

--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ func sendHelpMessage(client *slack.Client, jiraServer *jira.JiraServer, channel 
 func sendReminderMessage(client *slack.Client, channel string) {
 	time.Sleep(5 * time.Minute)
 	client.Send("Have you tried rolling back, scaling or restarting?", channel)
+	client.Send("Are users affected? Consider creating an incident on the status page.", channel)
 }
 
 func main() {
@@ -155,6 +156,9 @@ func main() {
 
 	// Link to flare resources
 	resources_url := os.Getenv("FLARE_RESOURCES_URL")
+
+	// Link to status page
+	status_page_url := os.Getenv("STATUS_PAGE_URL")
 
 	// Slack connection params
 	var accessToken string
@@ -318,12 +322,14 @@ func main() {
 		client.Send(fmt.Sprintf("JIRA ticket: %s", ticket.Url()), channel.ID)
 		client.Send(fmt.Sprintf("Facts docs: %s", doc.File.AlternateLink), channel.ID)
 		client.Send(fmt.Sprintf("Flare resources: %s", resources_url), channel.ID)
+		client.Send(fmt.Sprintf("Manage status page: %s", status_page_url), channel.ID)
 		client.Send(fmt.Sprintf("Remember: Rollback, Scale or Restart!"), channel.ID)
 
 		// Pin the most important messages. NOTE: that this is based on text
 		// matching, so the links need to be escaped to match
 		client.Pin(fmt.Sprintf("JIRA ticket: <%s>", ticket.Url()), channel.ID)
 		client.Pin(fmt.Sprintf("Facts docs: <%s>", doc.File.AlternateLink), channel.ID)
+		client.Pin(fmt.Sprintf("Manage status page: <%s>", status_page_url), channel.ID)
 		client.Pin(fmt.Sprintf("Remember: Rollback, Scale or Restart!"), channel.ID)
 
 		// send room-specific help


### PR DESCRIPTION
- adds and pins a message with a link to Clever's statuspage.io dashboard (I'll have to set the env var through heroku before deploying)
- adds a message about status page updates to the 5 minute reminder