### PR TITLE
Quietly fire preemptive flares

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,9 +239,13 @@ func main() {
 
 		// retroactive?
 		isRetroactive := strings.Contains(msg.Text, "retroactive")
+		// preemptive?
+		isPreemptive := strings.Contains(msg.Text, "emptive") // this could be pre-emptive, or preemptive
 
 		if isRetroactive {
 			client.Send("OK, let me quietly set up the Flare documents. Nobody freak out, this is retroactive.", msg.Channel)
+		} else if isPreemptive {
+			client.Send("OK, let me quietly set up the Flare documents. Nobody freak out, this is preemptive.", msg.Channel)
 		} else {
 			client.Send("OK, let me get my flaregun", msg.Channel)
 		}
@@ -343,7 +347,7 @@ func main() {
 		// announce the specific Flare room in the overall Flares room
 		target := "channel"
 
-		if isRetroactive {
+		if isRetroactive || isPreemptive {
 			author, _ := msg.AuthorUser()
 			target = author.Name
 		}


### PR DESCRIPTION
Pre-emptive flares by their nature should mean we don't need to freak out *yet*.

So when we fire a preemptive flare it should be quietly, like a retroactive flare. This will only notify the person firing the flare instead of @channel.

The difference between preemptive and retroactive flares is that retroactive flares are already marked as Mitigated while preemptive flares are not.