### PR TITLE
Stop ignoring error when getting channel info

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,10 @@ var channelNameRegexp = regexp.MustCompile("^([^-]+-[^-]+)(?:-.+)")
 
 func GetTicketFromCurrentChannel(client *slack.Client, JiraServer *jira.JiraServer, channelID string) (*jira.Ticket, error) {
 	// first more info about the channel
-	channel, _ := client.API.GetChannelInfo(channelID)
+	channel, err := client.API.GetChannelInfo(channelID)
+	if err != nil {
+		return nil, err
+	}
 
 	// we want to allow channel renaming as long as prefix remains #flare-<id>
 	channelName := channelNameRegexp.ReplaceAllString(channel.Name, "$1")


### PR DESCRIPTION
This is causing a nil pointer dereference on line 85 (channel.Name) when doing @flarebot help outside of a channel or in a channel that returns error from GetChannelInfo.