### PR TITLE
Move to non-deprecated api endpoint.

### DIFF
--- a/jira/jira.go
+++ b/jira/jira.go
@@ -126,7 +126,7 @@ func (server *JiraServer) TicketUrl(ticketKey string) string {
 
 func (server *JiraServer) GetUserByEmail(email string) (*User, error) {
 	var users []User
-	err := server.DoRequest("GET", fmt.Sprintf("/rest/api/2/user/search?username=%s", email), nil, &users)
+	err := server.DoRequest("GET", fmt.Sprintf("/rest/api/2/user/search?query=%s", email), nil, &users)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The username endpoint (and field) is being deprecated, so we should use a proper one.
In addition, JIRA is now pushing towards API tokens, so `username` is now email, and `password` is now the token.
Confirmed this change works - it's already running. :)