### PR TITLE
New endpoint which allows to not set priority which is possible in new gen projects

### DIFF
--- a/jira/jira_test.go
+++ b/jira/jira_test.go
@@ -125,6 +125,35 @@ func TestCreateTicket(t *testing.T) {
 	}
 }
 
+func TestCreateTicketNewGen(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	jiraServiceCalled := false
+
+	httpmock.RegisterResponder("POST", mockOrigin+"/rest/api/2/issue",
+		func(req *http.Request) (*http.Response, error) {
+			jiraServiceCalled = true
+
+			return httpmock.NewStringResponse(200, mockIssueContent), nil
+		},
+	)
+
+	testServer := CreateTestJiraServer()
+
+	theTicket, err := testServer.CreateTicketNewGen(nil, "It's a problem 2", &jira.User{
+		Name:         "alice.smith",
+		EmailAddress: "alice.smith@example.com",
+	})
+
+	assert.True(t, jiraServiceCalled)
+
+	assert.NoError(t, err)
+	if err == nil {
+		assert.Equal(t, theTicket.Key, mockIssueID)
+	}
+}
+
 func TestAssignTicketToUser(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()


### PR DESCRIPTION
New gen jira projects are more customizable and tend to not have all the fields that we use to `CreateTicket`. Note specifically it is the priority ticket that is sometimes optional (eg INFRANG doesn't have it)

Instead of creating a breaking change to createTicket like JIRA did I decided it was easier to add `createTicketNewGen`.

Tested by using this branch with my local specbot to create a ticket https://clever.slack.com/archives/C01JQDNPY5U/p1612240997007000