### PR TITLE
accept all whitespace before message

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -72,7 +72,7 @@ func (c *Client) Hear(pattern string, fn func(*Message, [][]string)) {
 }
 
 func (c *Client) Respond(pattern string, fn func(*Message, [][]string)) {
-	c.Hear(fmt.Sprintf("<@%s|%s>:? %s", c.Username, c.userId, pattern), fn)
+	c.Hear(fmt.Sprintf("<@%s|%s>:?\\s%s", c.Username, c.userId, pattern), fn)
 }
 
 func (c *Client) Send(msg, channelId string) {


### PR DESCRIPTION
This makes slackbot take any whitespace before the test command

From flarebot logs:
Content:"@flarebot\u00a0help"
(though it's unclear whether it converts the unicode before or after it does the regex, so if this doesn't work all add the "\u00a0" to the regex also)

Related:
https://clever.slack.com/archives/C063L91T7/p1618249962092500