### PR TITLE
accept whitespace and nbsp before message

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -72,7 +72,7 @@ func (c *Client) Hear(pattern string, fn func(*Message, [][]string)) {
 }
 
 func (c *Client) Respond(pattern string, fn func(*Message, [][]string)) {
-	c.Hear(fmt.Sprintf("<@%s|%s>:?\\s%s", c.Username, c.userId, pattern), fn)
+	c.Hear(fmt.Sprintf("<@%s|%s>:?(\\s*|\\\\u00a0)%s", c.Username, c.userId, pattern), fn)
 }
 
 func (c *Client) Send(msg, channelId string) {


### PR DESCRIPTION
Followup: 
https://github.com/Clever/flarebot/pull/112

Looks like only having \s doesn't work so trying to take the whole \u00a0. (needs double escape for sprintf and regex)