### PR TITLE
Switching to \W instead of \s

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -72,7 +72,7 @@ func (c *Client) Hear(pattern string, fn func(*Message, [][]string)) {
 }
 
 func (c *Client) Respond(pattern string, fn func(*Message, [][]string)) {
-	c.Hear(fmt.Sprintf("<@%s|%s>:?(\\s*|\\\\u00a0)%s", c.Username, c.userId, pattern), fn)
+	c.Hear(fmt.Sprintf("<@%s|%s>:?\\W*%s", c.Username, c.userId, pattern), fn)
 }
 
 func (c *Client) Send(msg, channelId string) {


### PR DESCRIPTION
nbsp doesn't get caught by golang regex with \s apparently, so \W will ignore any chunk until the first [a-zA-Z0-9] char after the "@flarebot"

Testing by deploying to prod 🙈 