### PR TITLE
IPOC-2220 assignee to be set by id instead of name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Link to JIRA
+[Link to JIRA](url)
+
+## Overview
+[insert description]
+
+## Testing
+
+## Rollout

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -170,7 +170,7 @@ func (server *JiraServer) CreateTicket(priority int, topic string, assignee *Use
 				"id": server.IssueTypeID,
 			},
 			"assignee": &map[string]interface{}{
-				"name": assignee.Name,
+				"accountId": assignee.AccountId,
 			},
 			"summary": topic,
 			"priority": &map[string]interface{}{
@@ -205,7 +205,7 @@ func (server *JiraServer) CreateTicketNewGen(priority *int, topic string, assign
 					"id": server.IssueTypeID,
 				},
 				"assignee": &map[string]interface{}{
-					"name": assignee.Name,
+					"accountId": assignee.AccountId,
 				},
 				"summary": topic,
 			},
@@ -220,7 +220,7 @@ func (server *JiraServer) CreateTicketNewGen(priority *int, topic string, assign
 					"id": server.IssueTypeID,
 				},
 				"assignee": &map[string]interface{}{
-					"name": assignee.Name,
+					"accountId": assignee.AccountId,
 				},
 				"summary": topic,
 				"priority": &map[string]interface{}{

--- a/main.go
+++ b/main.go
@@ -283,7 +283,7 @@ func main() {
 			client.Send(fmt.Sprintf("Unable to determine JIRA user by email: %s", author.Profile.Email), msg.Channel)
 		}
 
-		client.Send(fmt.Sprintf("JIRA username is %s", user.Name), msg.Channel)
+		client.Send(fmt.Sprintf("JIRA user ID is %s", user.AccountId), msg.Channel)
 
 		channel, err := client.API.GetConversationInfo(msg.Channel, false)
 		if err != nil {


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/IPOC-2220

## Overview
Assignee wasn't working because it was being set by name, which is `""` for all users coming back from Jira when you look them up by email address.

## Testing
Ran `bin/jira-cli` with my new createTicket test option. 
- I observed that before this change, when I would pass in my email address as the assignee, the ticket would still end up unassigned
- I observed that after this change, the ticket would end up assigned to me upon creation.

## Rollout
Will need to follow deployment procedure here: https://clever.atlassian.net/wiki/spaces/ENG/pages/81100842/Flarebot
and then probably can send the flarebot test command in slack to verify that everything is working well after deployment still.