### PR TITLE
IPOC-2248 fix flarebot crash when chatting from #flares-test

### DIFF
--- a/jira/testcmd/main.go
+++ b/jira/testcmd/main.go
@@ -82,6 +82,19 @@ func (jc *jiraCommand) CreateTicketCommand(cmd *cobra.Command, args []string) {
 	spew.Dump(ticket)
 }
 
+func (jc *jiraCommand) GetProjectCommand(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		log.Fatalf("A single jira project key must be provided\n")
+	}
+
+	project, err := jc.jiraServer.GetProjectByKey(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Project details:\n")
+	spew.Dump(project)
+}
+
 func main() {
 	jc := jiraCommand{
 		jiraServer: jira.JiraServer{
@@ -118,10 +131,17 @@ func main() {
 		Run:   jc.CreateTicketCommand,
 	}
 
+	var cmdGetProject = &cobra.Command{
+		Use:   "getProject <projectKey>",
+		Short: "print the project record for a jira project",
+		Run:   jc.GetProjectCommand,
+	}
+
 	var rootCmd = &cobra.Command{Use: "jira-cli"}
 	rootCmd.AddCommand(cmdGetUserByEmail)
 	rootCmd.AddCommand(cmdGetTicket)
 	rootCmd.AddCommand(cmdSetDescription)
 	rootCmd.AddCommand(cmdCreateTicket)
+	rootCmd.AddCommand(cmdGetProject)
 	rootCmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -229,7 +229,7 @@ func main() {
 		log.Fatalf("no JIRA project exists with id %s: %s", os.Getenv("JIRA_PROJECT_ID"), err.Error())
 	}
 
-	flareChannelNamePrefix = regexp.MustCompile(fmt.Sprintf("^%s-", strings.ToLower(jiraProject.Name)))
+	flareChannelNamePrefix = regexp.MustCompile(fmt.Sprintf("^%s-", strings.ToLower(jiraProject.Key)))
 
 	// Google Docs service
 	googleDocsServer, err := googledocs.NewGoogleDocsServerWithServiceAccount(os.Getenv("GOOGLE_FLAREBOT_SERVICE_ACCOUNT_CONF"))

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -108,7 +108,7 @@ func (c *Client) GetPin(pattern *regexp.Regexp, channelID string) (string, error
 			return m.Message.Text, nil
 		}
 	}
-	return "", nil
+	return "", fmt.Errorf("No pinned message matched the pattern")
 }
 
 func (c *Client) handleMessage(msg *slk.MessageEvent) {


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/IPOC-2248

## Overview
Flarebot had a couple of compounding issues:
- Was determining if a channel was a "flare" channel based on the FLARE project name, not key, so was looking for channels starting with "flares-" instead of "flare-"
- When looking for slack history google doc pinned message in flare channel, if there was non present, would crash because it still thought it had found one and treated the empty regex match as if it was a real match.

## Testing
We could hypothetically test this in the test slack instance as described on https://clever.atlassian.net/wiki/spaces/ENG/pages/81100842/Flarebot#:~:text=Running%20flarebot%20using%20test%20accounts but this is a minor enough change I was just going to deploy it and verify that it doesn't crash anymore when talking to flarebot in `#flares-test` instead of going through the process of running it against test accounts.

## Rollout
Follow :shipit: instructions in here: https://clever.atlassian.net/wiki/spaces/ENG/pages/81100842/Flarebot
Then observe that it doesn't crash.