### PR TITLE
Add support to mitigate/not a flare/unmitigate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 vendor/
 node_modules/
 dist/
+.cursor/

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -2,7 +2,7 @@ import config from "./config";
 
 function helpFlaresChannel(botUserId: string | undefined) {
   return `
-Commands available in the <#${config.FLARES_CHANNEL_ID}> channel:
+Commands available in the <#${config.FLARES_CHANNEL_ID}> channel: (Text in [ ] is optional)
 
 <@${botUserId}> help [all] - Display the list of commands available in this/all channel.
 <@${botUserId}> fire a flare <p0|p1|p2> [preemptive|retroactive] <title> - Fire a new Flare with the given priority and description. Optionally specify preemptive or retroactive. Ordering is not important but title should be last.
@@ -11,13 +11,14 @@ Commands available in the <#${config.FLARES_CHANNEL_ID}> channel:
 
 function helpFlareChannel(botUserId: string | undefined) {
   return `
-Commands available in a single Flare channel:
+Commands available in a flare channel: (Text in [ ] is optional)
 
 <@${botUserId}> help [all] - Display the list of commands available in this/all channel.
-<@${botUserId}> i am incident lead - Declare yourself incident lead.
-<@${botUserId}> i am comms lead - Declare yourself comms lead.
-<@${botUserId}> flare mitigated - Mark the Flare mitigated.
-<@${botUserId}> not a flare - Mark the Flare not-a-flare.
+<@${botUserId}> [i am] incident lead - Declare yourself incident lead.
+<@${botUserId}> [i am] comms lead - Declare yourself comms lead.
+<@${botUserId}> [flare is] mitigate[d] - Mark the Flare as mitigated.
+<@${botUserId}> [flare is] not a flare - Mark the Flare as not-a-flare.
+<@${botUserId}> [flare is] unmitigate[d] - Mark the Flare as in-progress.
 `;
 }
 

--- a/src/lib/introMessage.ts
+++ b/src/lib/introMessage.ts
@@ -1,7 +1,13 @@
 import { AnyBlock } from "@slack/types";
 import { recentDeploysActionID } from "./recentDeploys";
+import { helpFlareChannel } from "./help";
 
-const introMessage = (issueKey: string, flaredoc: string, slackHistoryDoc: string): AnyBlock[] => [
+const introMessage = (
+  issueKey: string,
+  flaredoc: string,
+  slackHistoryDoc: string,
+  botUserId: string,
+): AnyBlock[] => [
   {
     type: "section",
     text: {
@@ -10,70 +16,11 @@ const introMessage = (issueKey: string, flaredoc: string, slackHistoryDoc: strin
     },
   },
   {
-    type: "rich_text",
-    elements: [
-      {
-        type: "rich_text_section",
-        elements: [
-          {
-            type: "text",
-            text: "Here is a list of available commands\n",
-          },
-        ],
-      },
-      {
-        type: "rich_text_list",
-        style: "bullet",
-        indent: 0,
-        elements: [
-          {
-            type: "rich_text_section",
-            elements: [
-              {
-                type: "text",
-                text: "@flarebot i am incident lead",
-              },
-            ],
-          },
-          {
-            type: "rich_text_section",
-            elements: [
-              {
-                type: "text",
-                text: "@flarebot i am comms lead",
-              },
-            ],
-          },
-          {
-            type: "rich_text_section",
-            elements: [
-              {
-                type: "text",
-                text: "@flarebot flare mitigated",
-              },
-            ],
-          },
-          {
-            type: "rich_text_section",
-            elements: [
-              {
-                type: "text",
-                text: "@flarebot not a flare",
-              },
-            ],
-          },
-          {
-            type: "rich_text_section",
-            elements: [
-              {
-                type: "text",
-                text: "@flarebot generate summary",
-              },
-            ],
-          },
-        ],
-      },
-    ],
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: helpFlareChannel(botUserId),
+    },
   },
   {
     type: "section",

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -5,14 +5,17 @@ async function doJiraTransition(
   ticket: string,
   transitionName: string,
 ) {
-  const resp = await jiraclient.issues.getTransitions({
+  const jiraIssue = await jiraclient.issues.getIssue({
     issueIdOrKey: ticket,
+    expand: "transitions",
   });
 
-  const transition = resp.transitions?.find((t) => t.name === transitionName);
+  const transition = jiraIssue.transitions?.find((t) => t.to?.name === transitionName);
 
   if (!transition) {
-    throw new Error(`Transition ${transitionName} not found`);
+    throw new Error(
+      `Jira transition "${transitionName}" not found. Allowed transitions for current status: [${jiraIssue.transitions?.map((t) => t.to?.name).join(", ")}]`,
+    );
   }
 
   await jiraclient.issues.doTransition({

--- a/src/listeners/messages/flareTransition.test.ts
+++ b/src/listeners/messages/flareTransition.test.ts
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import { extractFlareTransition } from "./flareTransition";
+
+describe("extractFlareTransition", () => {
+  const testCases = [
+    // Positive cases
+    { text: "mitigated", expected: "mitigated" },
+    { text: "mitigate", expected: "mitigate" },
+    { text: "flare mitigated", expected: "mitigated" },
+    { text: "flare is mitigated", expected: "mitigated" },
+    { text: "unmitigated", expected: "unmitigated" },
+    { text: "unmitigate", expected: "unmitigate" },
+    { text: "flare unmitigated", expected: "unmitigated" },
+    { text: "not a flare", expected: "not a flare" },
+    { text: "not flare", expected: "not flare" },
+    { text: "flare not a flare", expected: "not a flare" },
+    { text: "flare not flare", expected: "not flare" },
+    { text: "flare is not a flare", expected: "not a flare" },
+    { text: "flare is not flare", expected: "not flare" },
+    { text: "MITIGATED", expected: "mitigated" },
+    { text: "UNMITIGATED", expected: "unmitigated" },
+    { text: "NOT A FLARE", expected: "not a flare" },
+    { text: "NOT FLARE", expected: "not flare" },
+    { text: "The flare is mitigated now", expected: "mitigated" },
+    { text: "Please mitigate the flare", expected: "mitigate" },
+    { text: "flare was mitigated", expected: "mitigated" },
+    { text: "mitigated flare", expected: "mitigated" },
+
+    // Negative cases
+    { text: "flare", expected: null },
+    { text: "mitigation", expected: null },
+    { text: "unmitigation", expected: null },
+    { text: "flare is", expected: null },
+    { text: "flare mitigation", expected: null },
+  ];
+
+  testCases.forEach(({ text, expected }) => {
+    test(`extracts "${expected}" from "${text}"`, () => {
+      const result = extractFlareTransition(text);
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/src/listeners/messages/flareTransition.ts
+++ b/src/listeners/messages/flareTransition.ts
@@ -1,0 +1,77 @@
+import { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
+import { Version3Client } from "jira.js";
+import { helpFlareChannel } from "../../lib/help";
+import { doJiraTransition } from "../../lib/jira";
+import config from "../../lib/config";
+
+const flareTransitionRegex =
+  /(?:flare )?(?:is )?(mitigat(?:ed|e)|not (?:a )?flare|unmitigat(?:ed|e))/i;
+
+async function flareTransition({
+  client,
+  message,
+  say,
+  context,
+}: AllMiddlewareArgs & SlackEventMiddlewareArgs<"message">) {
+  const jiraClient = context.clients.jiraClient as Version3Client;
+
+  if (message.subtype !== undefined) {
+    return;
+  }
+
+  const transition = extractFlareTransition(message.text ?? "");
+
+  if (!transition) {
+    await say({
+      text: `Sorry! I couldn't extract the flare transition from your message. ${helpFlareChannel(context.botUserId)}`,
+    });
+    return;
+  }
+
+  const jiraTicket = context.channel.name;
+  const channelId = context.channel.id;
+
+  try {
+    if (transition === "mitigated" || transition === "mitigate") {
+      await doJiraTransition(jiraClient, jiraTicket, "Mitigated");
+    } else if (transition === "not a flare" || transition === "not flare") {
+      await doJiraTransition(jiraClient, jiraTicket, "NotAFlare");
+    } else if (transition === "unmitigated" || transition === "unmitigate") {
+      await doJiraTransition(jiraClient, jiraTicket, "In Progress");
+    }
+  } catch (error) {
+    throw new Error(
+      "Error transitioning flare: " + error + ". You can manually transition the flare in Jira.",
+    );
+  }
+
+  let responseText = "";
+  let flareChannelText = "";
+  if (transition === "mitigated" || transition === "mitigate") {
+    responseText = "The Flare was mitigated and there was much rejoicing throughout the land.";
+    flareChannelText = `<#${channelId}> has been mitigated`;
+  } else if (transition === "not a flare" || transition === "not flare") {
+    responseText = "The Flare was not a Flare and there was much rejoicing throughout the land.";
+    flareChannelText = `turns out <#${channelId}> is not a Flare`;
+  } else if (transition === "unmitigated" || transition === "unmitigate") {
+    responseText = "UhOh! The Flare was unmitigated and the land is in chaos.";
+    flareChannelText = `<!channel> <#${channelId}> has been unmitigated and is back in progress.`;
+  }
+  await client.chat.postMessage({
+    channel: channelId,
+    thread_ts: message.ts,
+    text: responseText,
+  });
+  await client.chat.postMessage({
+    channel: config.FLARES_CHANNEL_ID,
+    text: flareChannelText,
+  });
+}
+
+function extractFlareTransition(text: string) {
+  const matches = text.toLowerCase().match(flareTransitionRegex);
+  if (!matches) return null;
+  return matches[1];
+}
+
+export { flareTransition, flareTransitionRegex, extractFlareTransition };

--- a/src/listeners/messages/help.ts
+++ b/src/listeners/messages/help.ts
@@ -5,9 +5,9 @@ import { helpAll, helpFlaresChannel, helpFlareChannel } from "../../lib/help";
 const helpRegex = /help\s*(all)?/i;
 
 async function help({
+  client,
   message,
   context,
-  say,
 }: AllMiddlewareArgs & SlackEventMiddlewareArgs<"message">) {
   if (message.subtype !== undefined && message.subtype !== "bot_message") {
     return;
@@ -24,7 +24,10 @@ async function help({
   } else {
     helpText = helpAll(context.botUserId);
   }
-  await say({
+
+  await client.chat.postMessage({
+    channel: context.channel.id,
+    thread_ts: message.ts,
     text: helpText,
   });
 }

--- a/src/listeners/messages/index.ts
+++ b/src/listeners/messages/index.ts
@@ -1,10 +1,12 @@
 import type { App } from "@slack/bolt";
 import { help, helpRegex } from "./help";
 import { fireAFlareRegex, fireFlare } from "./fireFlare";
+import { flareTransitionRegex, flareTransition } from "./flareTransition";
 
 const register = (app: App) => {
   app.message(fireAFlareRegex, fireFlare);
   app.message(helpRegex, help);
+  app.message(flareTransitionRegex, flareTransition);
 };
 
 export default { register };


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-7131

## Overview
Add support to mitigate/not a flare/unmitigate. Also updated a few places where error messages were not clearly posted to slack. I also slightly refactored the jira transition function to make it more extensible

## Testing
See flares-test slack channel. And also see the most recent flares. 

## Rollout
Blocked a bit on security. Current jira workflow doesn't allow a ticket in "NotAFlare" to become anything other than "New" but once fixed this PR should just work to transition from "NotAFlare" to anything else.
