### PR TITLE
add support to keep track of slack messages in a google sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@clever/catapult": "^1.208.0",
         "@googleapis/drive": "^13.0.1",
+        "@googleapis/sheets": "^11.1.0",
         "@slack/bolt": "^4.4.0",
         "clever-discovery": "^1.2.3",
         "google-auth-library": "^10.1.0",
@@ -740,6 +741,18 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-13.0.1.tgz",
       "integrity": "sha512-n6smJQyKTllRbXI8Xe/9IsCI+tuY20bhs9lircO+t2+a4k2t08NCZuujsBgIBTiE29v2kDzrrKdsuPxg5lUmXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^8.0.2-rc.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@googleapis/sheets": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sheets/-/sheets-11.1.0.tgz",
+      "integrity": "sha512-UsbODCbVpB3e0/kKCGy6QSgECl6nUAxCjJ7maXaeOWzQPpFLXtMX41l2TU76ze2F/Qxw8irvswFfx0vTORXsTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.2-rc.0"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@clever/catapult": "^1.208.0",
     "@googleapis/drive": "^13.0.1",
+    "@googleapis/sheets": "^11.1.0",
     "@slack/bolt": "^4.4.0",
     "clever-discovery": "^1.2.3",
     "google-auth-library": "^10.1.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,8 +4,12 @@ import kayvee from "kayvee";
 import middleware from "./middleware";
 import listeners from "./listeners";
 import clients from "./clients";
+import { UsersCache } from "./lib/usersCache";
+import { ChannelsCache } from "./lib/channelsCache";
 
 const logger = new kayvee.logger("flarebot");
+const usersCache = new UsersCache();
+const channelsCache = new ChannelsCache();
 
 const app = new App({
   token: config.SLACK_BOT_TOKEN,
@@ -14,9 +18,17 @@ const app = new App({
   appToken: config.SLACK_APP_TOKEN,
 });
 
-app.use(async ({ next, context }) => {
+app.use(async ({ next, context, client }) => {
   context.clients = clients;
   context.logger = logger;
+  // We add new users to slack once a day and they probably don't interact with flares on their first day
+  // so its okay to update cache just once every 24 hours.
+  if (usersCache.users.length === 0 || Date.now() - usersCache.lastUpdated > 1000 * 60 * 60 * 24) {
+    await usersCache.update(client);
+  }
+  context.usersCache = usersCache;
+  // channelsCache is updated as new channels are seen or created by flarebot
+  context.channelsCache = channelsCache;
   await next();
 });
 
@@ -25,6 +37,9 @@ app.use(async ({ next, context }) => {
 // app.use(async ({ next, payload, body, context }) => {
 //   console.log("payload", payload);
 //   console.log("body", body);
+
+//   console.log("users", context.usersCache.users.length);
+//   console.log("channels", context.channelsCache.channels);
 
 //   await next();
 // });

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,5 +1,6 @@
 import config from "../lib/config";
 import { drive } from "@googleapis/drive";
+import { sheets } from "@googleapis/sheets";
 import { GoogleAuth } from "google-auth-library";
 import { Version3Client } from "jira.js";
 import Catapult from "@clever/catapult";
@@ -24,6 +25,11 @@ const googleDriveClient = drive({
   auth: googleAuth,
 });
 
+const googleSheetsClient = sheets({
+  version: "v4",
+  auth: googleAuth,
+});
+
 const catapultClient = new Catapult({
   discovery: true,
 });
@@ -32,4 +38,5 @@ export default class clients {
   static jiraClient = jiraClient;
   static googleDriveClient = googleDriveClient;
   static catapultClient = catapultClient;
+  static googleSheetsClient = googleSheetsClient;
 }

--- a/src/lib/channelsCache.ts
+++ b/src/lib/channelsCache.ts
@@ -1,0 +1,81 @@
+import { GenericMessageEvent, KnownBlock, WebClient } from "@slack/web-api";
+import { Channel } from "@slack/web-api/dist/types/response/ConversationsInfoResponse";
+import config from "./config";
+
+class ChannelsCache {
+  channels: Record<string, { info: Channel; historyDocId?: string }>;
+
+  constructor() {
+    this.channels = {};
+  }
+
+  async getChannel(client: WebClient, channelId: string): Promise<Channel> {
+    let channel = this.channels[channelId];
+    if (!channel) {
+      const response = await client.conversations.info({
+        channel: channelId,
+      });
+      if (!response.channel) {
+        throw new Error(`Channel ${channelId} not found`);
+      }
+      channel = {
+        info: response.channel,
+      };
+      this.channels[channelId] = channel;
+    }
+    return channel.info;
+  }
+
+  async getChannelHistoryDocId(
+    client: WebClient,
+    channelId: string,
+    botUserId: string,
+  ): Promise<string | undefined> {
+    let channel = this.channels[channelId];
+    if (!channel || !channel.historyDocId) {
+      const info = await this.getChannel(client, channelId);
+      // only flare channels have a flare doc id
+      if (!info.name?.startsWith(config.FLARE_CHANNEL_PREFIX)) {
+        return undefined;
+      }
+      const pinedMessages = await client.pins.list({
+        channel: channelId,
+      });
+      // this can be simplified after https://github.com/slackapi/node-slack-sdk/issues/2316 is resolved
+      // currently the pins.list response type doesn't include the message
+      for (const pin of pinedMessages.items ?? []) {
+        if (pin.created_by === botUserId && pin.type === "message") {
+          const message = "message" in pin ? (pin.message as GenericMessageEvent) : undefined;
+          if (message && message.text?.startsWith("Thank you for firing a flare")) {
+            const lastBlock = message.blocks?.[message.blocks.length - 1] as KnownBlock;
+            if (lastBlock && lastBlock.type === "section") {
+              const lastBlockText = lastBlock.text?.text;
+              if (lastBlockText) {
+                const docIdMatch = lastBlockText.match(
+                  /docs\.google\.com\/spreadsheets\/d\/([a-zA-Z0-9_-]+)/,
+                );
+                if (docIdMatch) {
+                  channel = {
+                    info: info,
+                    historyDocId: docIdMatch[1],
+                  };
+                  this.channels[channelId] = channel;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return channel.historyDocId;
+  }
+
+  setChannel(channelId: string, channel: Channel, historyDocId?: string) {
+    this.channels[channelId] = {
+      info: channel,
+      historyDocId: historyDocId,
+    };
+  }
+}
+
+export { ChannelsCache };

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -2,7 +2,7 @@ import config from "./config";
 
 function helpFlaresChannel(botUserId: string | undefined) {
   return `
-Commands available in the <#${config.FLARES_CHANNEL_ID}> channel: (Text in [ ] is optional)
+Commands available in the <#${config.FLARES_CHANNEL_ID}> channel (Text in [ ] is optional):
 
 <@${botUserId}> help [all] - Display the list of commands available in this/all channel.
 <@${botUserId}> fire a flare <p0|p1|p2> [preemptive|retroactive] <title> - Fire a new Flare with the given priority and description. Optionally specify preemptive or retroactive. Ordering is not important but title should be last.
@@ -11,7 +11,7 @@ Commands available in the <#${config.FLARES_CHANNEL_ID}> channel: (Text in [ ] i
 
 function helpFlareChannel(botUserId: string | undefined) {
   return `
-Commands available in a flare channel: (Text in [ ] is optional)
+Commands available in a flare channel (Text in [ ] is optional):
 
 <@${botUserId}> help [all] - Display the list of commands available in this/all channel.
 <@${botUserId}> [i am] incident lead - Declare yourself incident lead.

--- a/src/lib/introMessage.ts
+++ b/src/lib/introMessage.ts
@@ -139,6 +139,8 @@ const introMessage = (
       },
     ],
   },
+  // if intro message is updated so that this block is not the last one
+  // then update recordMessage to account for the changes
   {
     type: "section",
     text: {

--- a/src/lib/usersCache.ts
+++ b/src/lib/usersCache.ts
@@ -1,0 +1,50 @@
+import { WebClient } from "@slack/web-api";
+import { Member } from "@slack/web-api/dist/types/response/UsersListResponse";
+
+class UsersCache {
+  users: Member[];
+  lastUpdated: number;
+
+  constructor() {
+    this.users = [];
+    this.lastUpdated = 0;
+  }
+
+  async update(client: WebClient) {
+    const allUsers: Member[] = [];
+    let cursor = undefined;
+    while (true) {
+      const response = await client.users.list({
+        cursor: cursor,
+      });
+      if (response.members) {
+        allUsers.push(...response.members);
+      }
+      cursor = response.response_metadata?.next_cursor;
+      if (!cursor) {
+        break;
+      }
+    }
+    this.users = allUsers;
+    this.lastUpdated = Date.now();
+  }
+
+  async getUser(client: WebClient, userId: string): Promise<Member | undefined> {
+    if (userId === "") {
+      return undefined;
+    }
+    let user = this.users.find((user) => user.id === userId);
+    if (!user) {
+      const userInfo = await client.users.info({
+        user: userId,
+      });
+      if (userInfo.user) {
+        user = userInfo.user;
+        this.users.push(user);
+      }
+    }
+    return user;
+  }
+}
+
+export { UsersCache };

--- a/src/listeners/messages/fireFlare.ts
+++ b/src/listeners/messages/fireFlare.ts
@@ -188,6 +188,7 @@ async function fireFlare({
     });
 
     flareChannelId = flareChannel.channel?.id ?? "";
+    context.channelsCache.setChannel(flareChannelId, flareChannel.channel, slackHistoryDocID);
   } catch (error) {
     throw new Error(
       `Error creating flare channel ${error}. If you need to make a new channel to discuss, please create a channel with name ${issueKey.toLowerCase()}.`,

--- a/src/middleware/blockAction.ts
+++ b/src/middleware/blockAction.ts
@@ -15,15 +15,8 @@ const blockActionMiddleware = async ({
 
   const now = new Date();
   try {
-    const userInfo = await client.users.info({
-      user: body.user.id,
-    });
-    context.user = userInfo.user;
-
-    const channelInfo = await client.conversations.info({
-      channel: body.channel?.id ?? "",
-    });
-    context.channel = channelInfo.channel;
+    context.user = await context.usersCache.getUser(client, body.user?.id ?? "");
+    context.channel = await context.channelsCache.getChannel(client, body.channel?.id ?? "");
 
     await next();
     context.logger.infoD("request-finished", {

--- a/src/middleware/message.ts
+++ b/src/middleware/message.ts
@@ -1,6 +1,9 @@
 import { helpAll } from "../lib/help";
 import config from "../lib/config";
-import { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
+import { AllMiddlewareArgs, Context, SlackEventMiddlewareArgs } from "@slack/bolt";
+import { AllMessageEvents } from "@slack/types";
+import { WebClient } from "@slack/web-api";
+import { ChannelsCache } from "../lib/channelsCache";
 
 const messageMiddleware = async ({
   payload,
@@ -8,15 +11,29 @@ const messageMiddleware = async ({
   context,
   next,
 }: AllMiddlewareArgs & SlackEventMiddlewareArgs<"message">) => {
-  // we don't care about all the subtypes. We only care about generic message events.
-  if (payload.type !== "message" || payload.subtype !== undefined) {
+  if (payload.type !== "message") {
     await next();
     return;
   }
 
-  // this middleware is only interested in messages that mention the bot.
+  try {
+    await recordMessage(payload, context, client);
+  } catch (error) {
+    // we don't want to block the main flow if we fail to record message history.
+    context.logger.errorD("record-message-error", {
+      payload: payload,
+      error: error,
+    });
+  }
+
+  // we don't care about all the subtypes. We only care about generic message events
+  // in future we could consider adding support for message_changed if requested
+  if (payload.subtype !== undefined) {
+    return;
+  }
+
+  // flarebot only cares about messages that mention the bot.
   if (payload.text && !payload.text.includes(`<@${context.botUserId}>`)) {
-    await next();
     return;
   }
 
@@ -29,26 +46,13 @@ const messageMiddleware = async ({
       });
       return;
     }
-    const userInfo = await client.users.info({
-      user: payload.user,
-    });
-    context.user = userInfo.user;
 
-    const channelInfo = await client.conversations.info({
-      channel: payload.channel,
-    });
-    if (!channelInfo.channel || !channelInfo.channel.name) {
-      await client.chat.postMessage({
-        channel: payload.channel,
-        text: `Sorry! Missing channel information.`,
-      });
-      return;
-    }
-    context.channel = channelInfo.channel;
+    context.user = await context.usersCache.getUser(client, payload.user);
+    context.channel = await context.channelsCache.getChannel(client, payload.channel);
 
     if (
-      channelInfo.channel.name === config.FLARES_CHANNEL_NAME ||
-      channelInfo.channel.name.startsWith(config.FLARE_CHANNEL_PREFIX)
+      context.channel.name === config.FLARES_CHANNEL_NAME ||
+      context.channel.name.startsWith(config.FLARE_CHANNEL_PREFIX)
     ) {
       await next();
       context.logger.infoD("request-finished", {
@@ -86,5 +90,96 @@ const messageMiddleware = async ({
     });
   }
 };
+
+async function recordMessage(payload: AllMessageEvents, context: Context, client: WebClient) {
+  const channelsCache = context.channelsCache as ChannelsCache;
+
+  const channelHistoryDocId = await channelsCache.getChannelHistoryDocId(
+    client,
+    payload.channel,
+    context.botUserId ?? "",
+  );
+
+  if (!channelHistoryDocId) {
+    return;
+  }
+
+  // there is no point in tracking every single message event. Lets do our best to track the most important ones.
+  let message = "";
+  let user = "";
+  if (payload.subtype === undefined) {
+    message = payload.text || "";
+    // this handles a bug in the slack api described here https://api.slack.com/events/message/message_replied
+    if (payload.thread_ts) {
+      message = `(message_replied ${payload.thread_ts}) ${message}`;
+    }
+    user = payload.user;
+  } else if (payload.subtype === "message_replied") {
+    if ("text" in payload.message && payload.message.text) {
+      message = `(message_replied ${payload.message.thread_ts}): ${payload.message.text}`;
+    }
+    if ("user" in payload.message && payload.message.user) {
+      user = payload.message.user;
+    }
+  } else if (payload.subtype === "message_changed") {
+    if (
+      "text" in payload.message &&
+      payload.message.text &&
+      "text" in payload.previous_message &&
+      payload.previous_message.text &&
+      payload.message.text !== payload.previous_message.text
+    ) {
+      message = `(message_changed ${payload.message.ts}): ${payload.message.text}`;
+    }
+    if ("user" in payload.message && payload.message.user) {
+      user = payload.message.user;
+    }
+  } else if (payload.subtype === "message_deleted") {
+    message = `(message_deleted ${payload.previous_message.ts}): Message deleted`;
+    if ("user" in payload.previous_message && payload.previous_message.user) {
+      user = payload.previous_message.user;
+    }
+  } else if (payload.subtype === "channel_join" || payload.subtype === "channel_leave") {
+    message = payload.text || "";
+    user = payload.user;
+  }
+  if (message === "" || user === "") {
+    context.logger.debugD("message-not-recorded", { payload: payload });
+    return;
+  }
+
+  // Replace Slack user mentions with actual names in the message
+  const mentionMatches = message.match(/<@([A-Z0-9]+)>/g);
+  if (mentionMatches) {
+    for (const match of mentionMatches) {
+      const userId = match.match(/<@([A-Z0-9]+)>/)?.[1];
+      if (userId) {
+        const user = await context.usersCache.getUser(client, userId);
+        const userName = user ? `@${user.real_name || user.name || userId}` : match;
+        message = message.replace(match, userName);
+      }
+    }
+  }
+
+  const author = await context.usersCache.getUser(client, user);
+
+  await context.clients.googleSheetsClient.spreadsheets.values.append({
+    spreadsheetId: channelHistoryDocId,
+    range: "Sheet1",
+    valueInputOption: "USER_ENTERED",
+    insertDataOption: "INSERT_ROWS",
+    requestBody: {
+      values: [
+        [
+          payload.ts,
+          new Date(parseInt(payload.ts) * 1000).toLocaleString("en-US", { timeZone: "US/Pacific" }),
+          author ? `${author.real_name || author.name || author.id}` : user,
+          message,
+        ],
+      ],
+      majorDimension: "ROWS",
+    },
+  });
+}
 
 export { messageMiddleware };


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-7127

## Overview
This PR adds support to record all relevant message events in the google sheet we created when a flare is fired. I added some improvements over the current flarebot
- keeps tracks of message edits and deletes
- explicitly lists if a message is a reply in a thread
- replaces <@U1234567890> type user ids with user's name

At every message we want to avoid querying userid -> username and channel id -> channel name -> flaredoc so I also created a cache of these. The user cache also updates every 24 hours. Sorry for the big PR! 

## Testing
See flaretest-74 and https://docs.google.com/spreadsheets/d/1jMwfbf2sjtod36y12iTvQy_xqnuC0HeG83T_l0FmQ2Y/edit?gid=0#gid=0

## Rollout
