### PR TITLE
add flare title in the fired message

### DIFF
--- a/src/listeners/messages/fireFlare.ts
+++ b/src/listeners/messages/fireFlare.ts
@@ -242,7 +242,7 @@ async function fireFlare({
     audience = `<@${context.user.id}>`;
   }
   await say({
-    text: `${audience}: Flare fired. Please visit <#${flareChannelId}>`,
+    text: `${audience}: Flare fired. Please visit <#${flareChannelId}> -- ${title}`,
   });
 }
 


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-7315

## Overview
We received the following feedback so lets add back the title.

>One thing I miss from the old flarebot was that when a flare was fired, when it would ping @channel in [#flares](https://clever.slack.com/archives/C07DMESMQ), it used to include the description of the flare that the user provided in that message along with the flare channel number, like [this](https://clever.slack.com/archives/C07DMESMQ/p1754418466227369), which I used to find very helpful for seeing at a glance in my notifications what a fired flare was about. In the new flarebot, the messages look like [this](https://clever.slack.com/archives/C07DMESMQ/p1755555471578149), which means that when I see the notification, I have to either go the the [#flares](https://clever.slack.com/archives/C07DMESMQ) channel or to the flare-ticket channel to see what the flare is about, rather than seeing what it is about from the @channel notification.

## Testing
Very simple that we don't need to test

## Rollout
