### PR TITLE
Infrang 7282

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import listeners from "./listeners";
 import clients from "./clients";
 import { UsersCache } from "./lib/usersCache";
 import { ChannelsCache } from "./lib/channelsCache";
+import { uploadFiles } from "./lib/uploadFiles";
 
 const logger = new kayvee.logger("flarebot");
 const usersCache = new UsersCache();
@@ -50,4 +51,17 @@ listeners.register(app);
 (async () => {
   await app.start();
   app.logger.info("⚡️ Bolt app is running!");
+})();
+
+// background tasks
+(async () => {
+  while (true) {
+    try {
+      const self = await app.client.auth.test();
+      await uploadFiles(app.client, self.user_id ?? "");
+    } catch (error) {
+      logger.errorD("upload-files-error", { error: error });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 24 * 60 * 60 * 1000));
+  }
 })();

--- a/src/lib/debugging101.ts
+++ b/src/lib/debugging101.ts
@@ -2,7 +2,7 @@ import { ModalView } from "@slack/types";
 
 const debugging101ActionID = "debugging101";
 
-const debugging101ModalView = (): ModalView => {
+const debugging101ModalView = (fileId: string): ModalView => {
   return {
     type: "modal",
     title: {
@@ -27,7 +27,7 @@ const debugging101ModalView = (): ModalView => {
       {
         type: "image",
         slack_file: {
-          id: "F0990KPQFRA", // Hard code this for now but we should look it up from slack based on file name
+          id: fileId,
         },
         alt_text: "Debuging 101",
       },

--- a/src/lib/howToPage.ts
+++ b/src/lib/howToPage.ts
@@ -2,7 +2,7 @@ import { ModalView } from "@slack/types";
 
 const howToPageActionID = "how_to_page";
 
-const howToPageModalView = (): ModalView => {
+const howToPageModalView = (fileId: string): ModalView => {
   return {
     type: "modal",
     title: {
@@ -35,7 +35,7 @@ You can also page a specific person by clicking "Add details" and then searching
       {
         type: "image",
         slack_file: {
-          id: "F098JQQE9N3", // Hard code this for now but we should look it up from slack based on file name F0990KPQFRA
+          id: fileId,
         },
         alt_text: "/pd trigger",
       },

--- a/src/lib/uploadFiles.ts
+++ b/src/lib/uploadFiles.ts
@@ -1,0 +1,36 @@
+import { WebClient } from "@slack/web-api";
+import fs from "fs";
+
+async function uploadFiles(client: WebClient, botId: string) {
+  // get all files in the images directory
+  const files = fs.readdirSync("src/lib/images");
+
+  const userfiles = await client.files.list({
+    user: botId,
+    types: "images",
+  });
+
+  const userfilesMap = new Map(userfiles.files?.map((file) => [file.name, file]) ?? []);
+
+  for (const file of files) {
+    if (file === "README.md") {
+      continue;
+    }
+
+    if (userfilesMap.has(file)) {
+      continue;
+    }
+
+    const response = await client.filesUploadV2({
+      file: `src/lib/images/${file}`,
+      filename: file,
+      title: file,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to upload file ${file}: ${response.error}`);
+    }
+  }
+}
+
+export { uploadFiles };

--- a/src/listeners/actions/debugging101.ts
+++ b/src/listeners/actions/debugging101.ts
@@ -1,16 +1,30 @@
 import { AllMiddlewareArgs, SlackActionMiddlewareArgs } from "@slack/bolt";
 import { BlockAction } from "@slack/bolt/dist/types/actions";
 import { debugging101ModalView } from "../../lib/debugging101";
+import { uploadFiles } from "../../lib/uploadFiles";
 
 const debugging101 = async ({
   client,
   body,
   ack,
+  context,
 }: AllMiddlewareArgs & SlackActionMiddlewareArgs<BlockAction>) => {
   await ack();
+
+  const files = await client.files.list({
+    user: context.botUserId,
+    types: "images",
+  });
+
+  const filesMap = new Map(files.files?.map((file) => [file.name, file]) ?? []);
+
+  if (!filesMap.has("debugging-101.png")) {
+    await uploadFiles(client, context.botUserId ?? "");
+  }
+
   await client.views.open({
     trigger_id: body.trigger_id,
-    view: debugging101ModalView(),
+    view: debugging101ModalView(filesMap.get("debugging-101.png")?.id ?? ""),
   });
 };
 

--- a/src/listeners/actions/howToPage.ts
+++ b/src/listeners/actions/howToPage.ts
@@ -1,16 +1,30 @@
 import { AllMiddlewareArgs, SlackActionMiddlewareArgs } from "@slack/bolt";
 import { BlockAction } from "@slack/bolt/dist/types/actions";
 import { howToPageModalView } from "../../lib/howToPage";
+import { uploadFiles } from "../../lib/uploadFiles";
 
 const howToPage = async ({
   client,
   body,
+  context,
   ack,
 }: AllMiddlewareArgs & SlackActionMiddlewareArgs<BlockAction>) => {
   await ack();
+
+  const files = await client.files.list({
+    user: context.botUserId,
+    types: "images",
+  });
+
+  const filesMap = new Map(files.files?.map((file) => [file.name, file]) ?? []);
+
+  if (!filesMap.has("pd-trigger.png")) {
+    await uploadFiles(client, context.botUserId ?? "");
+  }
+
   await client.views.open({
     trigger_id: body.trigger_id,
-    view: howToPageModalView(),
+    view: howToPageModalView(filesMap.get("pd-trigger.png")?.id ?? ""),
   });
 };
 


### PR DESCRIPTION
## Clever Coding Standards Agreement
- [x] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-7282

## Overview
We use some images in our modals. Currently these file ids are hardcoded and images were uploaded manually but as we have a retention policy in slack they will get deleted. With this change we are dynamically getting file ids and re uploading if the file gets deleted.

I also decided to move user cache refresh to background tasks instead of at every message

## Testing
Tested by running locally and verifying that the modals are still opening.

## Rollout