### PR TITLE
assign incident lead anytime a flare is transitioned

### DIFF
--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -4,6 +4,7 @@ async function doJiraTransition(
   jiraclient: Version3Client,
   ticket: string,
   transitionName: string,
+  assignee?: string,
 ) {
   const jiraIssue = await jiraclient.issues.getIssue({
     issueIdOrKey: ticket,
@@ -22,6 +23,15 @@ async function doJiraTransition(
     issueIdOrKey: ticket,
     transition: transition,
   });
+
+  if (assignee) {
+    await jiraclient.issues.editIssue({
+      issueIdOrKey: ticket,
+      fields: {
+        assignee: { id: assignee },
+      },
+    });
+  }
 }
 
 const jiraDescription = (flaredoc: string, slackHistoryDoc: string) => ({

--- a/src/listeners/messages/fireFlare.ts
+++ b/src/listeners/messages/fireFlare.ts
@@ -62,6 +62,10 @@ async function fireFlare({
       query: context.user.profile.email,
     });
 
+    if (!jiraUser || jiraUser.length === 0) {
+      throw new Error("Could not find your JIRA user account");
+    }
+
     const newIssue = await jiraClient.issues.createIssue({
       fields: {
         summary: title,

--- a/src/listeners/messages/flareTransition.ts
+++ b/src/listeners/messages/flareTransition.ts
@@ -34,12 +34,20 @@ async function flareTransition({
   const channelId = context.channel.id;
 
   try {
+    const jiraUser = await jiraClient.userSearch.findUsers({
+      query: context.user.profile.email,
+    });
+
+    if (!jiraUser || jiraUser.length === 0) {
+      throw new Error("Could not find your JIRA user account");
+    }
+
     if (transition === "mitigated" || transition === "mitigate") {
-      await doJiraTransition(jiraClient, jiraTicket, "Mitigated");
+      await doJiraTransition(jiraClient, jiraTicket, "Mitigated", jiraUser[0].accountId);
     } else if (transition === "not a flare" || transition === "not flare") {
-      await doJiraTransition(jiraClient, jiraTicket, "NotAFlare");
+      await doJiraTransition(jiraClient, jiraTicket, "NotAFlare", jiraUser[0].accountId);
     } else if (transition === "unmitigated" || transition === "unmitigate") {
-      await doJiraTransition(jiraClient, jiraTicket, "In Progress");
+      await doJiraTransition(jiraClient, jiraTicket, "In Progress", jiraUser[0].accountId);
     }
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [x] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-7359

## Overview
There was a regression from the old bot behavior. We used to assign incident lead anytime flare mitigated. The new bot just does the transition. In this PR we are updating the behavior to match the old bot and additionally on any type of transition incident lead is now updated to the person that gave the command.

## Testing
Did a bunch of testing in `flaretest-66` 

## Rollout