### PR TITLE
update circleci script to fix publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ executors:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
       MASTER_COMPARE: master...<<pipeline.git.branch>>
+      PREVIOUS_PIPELINE_COMPARE: << pipeline.git.base_revision >>..<<pipeline.git.revision>>
 
 commands:
   clone-ci-scripts:


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## Link to JIRA
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-7267)

## Overview
This PR https://github.com/Clever/flarebot/pull/152 was merged to master and the circleci workflow is failing due to a missing env variable:
https://app.circleci.com/pipelines/github/Clever/flarebot/178/workflows/59e77981-75dc-4880-93ae-faf51c119107/jobs/784

Setting the variable to fix the publish step. 

## Testing
* circleci build passed on the PR

## Rollout
* Merge to master